### PR TITLE
Add feature to show active games

### DIFF
--- a/apps/game_engine/lib/game_engine.ex
+++ b/apps/game_engine/lib/game_engine.ex
@@ -8,18 +8,49 @@ defmodule GameEngine do
   defdelegate join_player(game, player), to: GameServer
   defdelegate put_player_symbol(game, symbol, pos), to: GameServer
   defdelegate new_round(game), to: GameServer
-  defdelegate leave(game, symbol), to: GameServer
   defdelegate active_games, to: GameListRegistry
 
   @doc """
-  Finds or create a `GameServer` process under `GameSupervisor`.
+  Find or create a `GameServer` process under `GameSupervisor`.
+
+  ### Examples
+
+    iex> GameEngine.find_or_create_game("my-game")
+    "my-game"
+
   """
   def find_or_create_game(game_name) do
     if GameSupervisor.game_exists?(game_name) do
       game_name
     else
       {:ok, _pid} = GameSupervisor.create_game(game_name)
+
+      PubSub.broadcast(:game_created)
+
       game_name
+    end
+  end
+
+  @doc """
+  Leave the given symbol from the game.
+
+  It will broadcast the event `:game_closed` once the game process is closed when the last player
+  leaves the game.
+
+  ### Examples
+
+    iex> Game.leave("game-1", :x)
+    {:ok, %Game{...}}
+
+  """
+  def leave(game, symbol) do
+    case GameServer.leave(game, symbol) do
+      {:ok, game_state} ->
+        {:ok, game_state}
+
+      {:closed, game_state} ->
+        PubSub.broadcast(:game_closed)
+        {:ok, game_state}
     end
   end
 

--- a/apps/game_engine/lib/game_engine.ex
+++ b/apps/game_engine/lib/game_engine.ex
@@ -3,12 +3,13 @@ defmodule GameEngine do
   Expose all public API's for projects that depend on `GameEngine`.
   """
 
-  alias GameEngine.{GameServer, GameSupervisor, PubSub}
+  alias GameEngine.{GameServer, GameSupervisor, GameListRegistry, PubSub}
 
   defdelegate join_player(game, player), to: GameServer
   defdelegate put_player_symbol(game, symbol, pos), to: GameServer
   defdelegate new_round(game), to: GameServer
   defdelegate leave(game, symbol), to: GameServer
+  defdelegate active_games, to: GameListRegistry
 
   @doc """
   Finds or create a `GameServer` process under `GameSupervisor`.

--- a/apps/game_engine/lib/game_engine.ex
+++ b/apps/game_engine/lib/game_engine.ex
@@ -3,7 +3,7 @@ defmodule GameEngine do
   Expose all public API's for projects that depend on `GameEngine`.
   """
 
-  alias GameEngine.{GameServer, GameSupervisor}
+  alias GameEngine.{GameServer, GameSupervisor, PubSub}
 
   defdelegate join_player(game, player), to: GameServer
   defdelegate put_player_symbol(game, symbol, pos), to: GameServer
@@ -20,5 +20,20 @@ defmodule GameEngine do
       {:ok, _pid} = GameSupervisor.create_game(game_name)
       game_name
     end
+  end
+
+  @doc """
+  Subscribe to the given event_types.
+
+  Check `PubSub.subscribe/1` to see the event types supported.
+
+  ### Examples
+
+    iex> GameEngine.subscribe([:game_created, :game_closed])
+    :ok
+
+  """
+  def subscribe(event_types) do
+    for event_type <- event_types, do: PubSub.subscribe(event_type)
   end
 end

--- a/apps/game_engine/lib/game_engine/application.ex
+++ b/apps/game_engine/lib/game_engine/application.ex
@@ -8,6 +8,7 @@ defmodule GameEngine.Application do
 
     children = [
       {Registry, keys: :unique, name: :game_server_registry},
+      {Registry, keys: :duplicate, name: Registry.GameEngineEvents},
       GameSupervisor
     ]
 

--- a/apps/game_engine/lib/game_engine/application.ex
+++ b/apps/game_engine/lib/game_engine/application.ex
@@ -9,6 +9,7 @@ defmodule GameEngine.Application do
     children = [
       {Registry, keys: :unique, name: :game_server_registry},
       {Registry, keys: :duplicate, name: Registry.GameEngineEvents},
+      {Registry, keys: :duplicate, name: Registry.GameList},
       GameSupervisor
     ]
 

--- a/apps/game_engine/lib/game_engine/game.ex
+++ b/apps/game_engine/lib/game_engine/game.ex
@@ -11,7 +11,8 @@ defmodule GameEngine.Game do
             next: :x,
             first: :x,
             finished: false,
-            winner: nil
+            winner: nil,
+            name: nil
 
   @doc """
   Changes the given game to finished.

--- a/apps/game_engine/lib/game_engine/game_list_registry.ex
+++ b/apps/game_engine/lib/game_engine/game_list_registry.ex
@@ -1,0 +1,26 @@
+defmodule GameEngine.GameListRegistry do
+  @moduledoc """
+  Module responsible to control the active games.
+
+  Once the `game_name` is a process' name, we can use `Registry` to track this process state and
+  then list the active games.
+  """
+
+  @registry_name Registry.GameList
+
+  @doc """
+  Register a game process given its name.
+  """
+  def register(game_name) do
+    Registry.register(@registry_name, :active_games, game_name)
+  end
+
+  @doc """
+  Return a list with the active games.
+  """
+  def active_games do
+    @registry_name
+    |> Registry.lookup(:active_games)
+    |> Enum.map(fn {_, name} -> name end)
+  end
+end

--- a/apps/game_engine/lib/game_engine/game_server.ex
+++ b/apps/game_engine/lib/game_engine/game_server.ex
@@ -19,7 +19,9 @@ defmodule GameEngine.GameServer do
   It uses `via_tuple/1` to registry this process and its PID in the Registry.
   """
   def start_link(name, initial_state \\ %Game{}) do
-    GenServer.start_link(__MODULE__, initial_state, name: via_tuple(name))
+    game = %{initial_state | name: name}
+
+    GenServer.start_link(__MODULE__, game, name: via_tuple(name))
   end
 
   @doc """

--- a/apps/game_engine/lib/game_engine/game_server.ex
+++ b/apps/game_engine/lib/game_engine/game_server.ex
@@ -7,7 +7,7 @@ defmodule GameEngine.GameServer do
   leaving the game, use `leave/2`.
   """
 
-  alias GameEngine.{Board, Game}
+  alias GameEngine.{Board, Game, GameListRegistry}
 
   use GenServer
 
@@ -90,6 +90,8 @@ defmodule GameEngine.GameServer do
 
   @impl true
   def init(game \\ %Game{}) do
+    GameListRegistry.register(game.name)
+
     {:ok, game}
   end
 

--- a/apps/game_engine/lib/game_engine/game_server.ex
+++ b/apps/game_engine/lib/game_engine/game_server.ex
@@ -167,7 +167,7 @@ defmodule GameEngine.GameServer do
       |> Game.reset_board()
 
     if Game.without_players?(new_state) do
-      {:stop, :normal, {:ok, new_state}, new_state}
+      {:stop, :normal, {:closed, new_state}, new_state}
     else
       {:reply, {:ok, new_state}, new_state}
     end

--- a/apps/game_engine/lib/game_engine/pub_sub.ex
+++ b/apps/game_engine/lib/game_engine/pub_sub.ex
@@ -1,0 +1,39 @@
+defmodule GameEngine.PubSub do
+  @moduledoc """
+  Provide functions to broadcast and subscribe events to listen in other process.
+  """
+
+  @event_types ~w(game_created game_closed)a
+  @registry_name Registry.GameEngineEvents
+
+  @doc """
+  Broadcast the given event type to all subscribers.
+
+  ## Examples
+
+    iex> GameEngine.PubSub.broadcast(:game_created)
+    :ok
+  """
+  def broadcast(event_type) when event_type in @event_types do
+    Registry.dispatch(@registry_name, event_type, &dispatch_for_subscribers(&1, event_type))
+  end
+
+  defp dispatch_for_subscribers(entries, event_type) do
+    for {pid, _registered_val} <- entries, do: send(pid, {:game_engine_event, event_type})
+  end
+
+  @doc """
+  Subscribe to the given event type.
+
+  Once a process has subscribed, make sure to implement callbacks to `{:game_engine_event, event_type}` message.
+
+  ## Examples
+
+    iex> GameEngine.PubSub.subscribe(:game_created)
+    :ok
+  """
+  def subscribe(event_type) when event_type in @event_types do
+    {:ok, _pid} = Registry.register(@registry_name, event_type, [])
+    :ok
+  end
+end

--- a/apps/game_engine/test/game_engine/game_server_test.exs
+++ b/apps/game_engine/test/game_engine/game_server_test.exs
@@ -27,7 +27,8 @@ defmodule GameEngine.GameServerTest do
            next: :x,
            o: nil,
            winner: nil,
-           x: "Felipe"
+           x: "Felipe",
+           name: @game_name
          }}
 
       assert GameServer.join_player(@game_name, player) == expected
@@ -50,7 +51,8 @@ defmodule GameEngine.GameServerTest do
            next: :x,
            o: "Renan",
            winner: nil,
-           x: "Felipe"
+           x: "Felipe",
+           name: @game_name
          }}
 
       assert GameServer.join_player(@game_name, player_o) == expected
@@ -101,7 +103,8 @@ defmodule GameEngine.GameServerTest do
            next: :o,
            o: "Renan",
            winner: nil,
-           x: "Felipe"
+           x: "Felipe",
+           name: @game_name
          }}
 
       assert GameServer.put_player_symbol(@game_name, player_x, position) == expected
@@ -141,7 +144,8 @@ defmodule GameEngine.GameServerTest do
            next: :x,
            o: "Renan",
            winner: :x,
-           x: "Felipe"
+           x: "Felipe",
+           name: @game_name
          }}
 
       assert GameServer.put_player_symbol(@game_name, player_x, position) == expected
@@ -169,7 +173,8 @@ defmodule GameEngine.GameServerTest do
            next: :o,
            o: "Renan",
            winner: :draw,
-           x: "Felipe"
+           x: "Felipe",
+           name: @game_name
          }}
 
       assert GameServer.put_player_symbol(@game_name, player_o, position) == expected
@@ -198,7 +203,8 @@ defmodule GameEngine.GameServerTest do
            next: :o,
            o: "Renan",
            winner: nil,
-           x: "Felipe"
+           x: "Felipe",
+           name: @game_name
          }}
 
       assert GameServer.new_round(@game_name) == expected
@@ -223,7 +229,8 @@ defmodule GameEngine.GameServerTest do
            next: :x,
            o: "Renan",
            winner: nil,
-           x: nil
+           x: nil,
+           name: @game_name
          }}
 
       assert GameServer.leave(@game_name, player_x) == expected

--- a/apps/game_engine/test/game_engine/pub_sub_test.exs
+++ b/apps/game_engine/test/game_engine/pub_sub_test.exs
@@ -1,0 +1,32 @@
+defmodule GameEngine.PubSubTest do
+  use ExUnit.Case, async: true
+
+  alias GameEngine.PubSub
+
+  doctest PubSub
+
+  describe "broadcast/1" do
+    test "broadcast an :game_created event" do
+      event_type = :game_created
+
+      assert PubSub.broadcast(event_type) == :ok
+    end
+
+    test "broadcast an :game_closed event" do
+      event_type = :game_closed
+
+      assert PubSub.broadcast(event_type) == :ok
+    end
+  end
+
+  describe "subscribe/1" do
+    test "subscribe to game engine event" do
+      event_type = :game_created
+
+      PubSub.subscribe(event_type)
+      PubSub.broadcast(event_type)
+
+      assert_received {:game_engine_event, ^event_type}
+    end
+  end
+end

--- a/apps/game_ui/assets/css/app.css
+++ b/apps/game_ui/assets/css/app.css
@@ -6,6 +6,7 @@
 @import "./new-game.css";
 @import "./phoenix.css";
 @import "./player.css";
+@import "./game-list.css";
 
 .msg {
   margin-top: 200px;
@@ -18,12 +19,6 @@
   display: inline-block;
   text-align: center;
   margin: 0 30px;
-}
-
-.form {
-  text-align: center;
-  width: 300px;
-  margin: 200px auto;
 }
 
 .hidden {

--- a/apps/game_ui/assets/css/game-list.css
+++ b/apps/game_ui/assets/css/game-list.css
@@ -1,0 +1,12 @@
+.game-list__link {
+  padding: 1rem;
+  display: block;
+  font-weight: 500;
+  font-size: 1.875rem;
+}
+
+.game-list__item {
+  list-style: none;
+  margin: 0;
+  margin-top: 1px;
+}

--- a/apps/game_ui/lib/game_ui_web.ex
+++ b/apps/game_ui/lib/game_ui_web.ex
@@ -24,6 +24,8 @@ defmodule GameUiWeb do
       import Plug.Conn
       import GameUiWeb.Gettext
       import GameUiWeb.Router.Helpers
+
+      import Phoenix.LiveView.Controller, only: [live_render: 3]
     end
   end
 

--- a/apps/game_ui/lib/game_ui_web/controllers/game_controller.ex
+++ b/apps/game_ui/lib/game_ui_web/controllers/game_controller.ex
@@ -1,8 +1,6 @@
 defmodule GameUiWeb.GameController do
   use GameUiWeb, :controller
 
-  alias Phoenix.LiveView
-
   plug :check_player
 
   def new(conn, _params) do
@@ -23,7 +21,7 @@ defmodule GameUiWeb.GameController do
 
   def show(conn, %{"name" => name}) do
     session = %{game_name: name, current_player: conn.assigns.current_player}
-    LiveView.Controller.live_render(conn, GameUiWeb.GameLive, session: session)
+    live_render(conn, GameUiWeb.GameLive, session: session)
   end
 
   defp check_player(conn, _options) do

--- a/apps/game_ui/lib/game_ui_web/live/game_list_live.ex
+++ b/apps/game_ui/lib/game_ui_web/live/game_list_live.ex
@@ -11,7 +11,7 @@ defmodule GameUiWeb.GameListLive do
     <ul class="game-list">
     <%= for game <- @games do %>
       <li class="game-list__item">
-        <%= link game, to: Routes.game_path(@socket, :show, game), class: "game-list__link" %>
+        <%= link "# " <> game, to: Routes.game_path(@socket, :show, game), class: "game-list__link" %>
       </li>
       <% end %>
     </ul>

--- a/apps/game_ui/lib/game_ui_web/live/game_list_live.ex
+++ b/apps/game_ui/lib/game_ui_web/live/game_list_live.ex
@@ -1,0 +1,37 @@
+defmodule GameUiWeb.GameListLive do
+  use Phoenix.LiveView
+
+  import Phoenix.HTML.Link, only: [link: 2]
+
+  alias GameUiWeb.Router.Helpers, as: Routes
+
+  @impl true
+  def render(assigns) do
+    ~L"""
+    <ul class="game-list">
+    <%= for game <- @games do %>
+      <li class="game-list__item">
+        <%= link game, to: Routes.game_path(@socket, :show, game), class: "game-list__link" %>
+      </li>
+      <% end %>
+    </ul>
+    """
+  end
+
+  @impl true
+  def mount(_session, socket) do
+    GameEngine.subscribe(~w(game_created game_closed)a)
+
+    {:ok, assign(socket, games: GameEngine.active_games())}
+  end
+
+  @impl true
+  def handle_info({:game_engine_event, :game_created}, socket) do
+    {:noreply, assign(socket, games: GameEngine.active_games())}
+  end
+
+  @impl true
+  def handle_info({:game_engine_event, :game_closed}, socket) do
+    {:noreply, assign(socket, games: GameEngine.active_games())}
+  end
+end

--- a/apps/game_ui/lib/game_ui_web/plugs/player.ex
+++ b/apps/game_ui/lib/game_ui_web/plugs/player.ex
@@ -1,6 +1,5 @@
 defmodule GameUiWeb.Plugs.Player do
   import Plug.Conn
-  import Phoenix.Controller
 
   def init(options) do
     options

--- a/apps/game_ui/lib/game_ui_web/templates/game/new.html.eex
+++ b/apps/game_ui/lib/game_ui_web/templates/game/new.html.eex
@@ -1,11 +1,15 @@
-<div class="form">
-  <%= form_for @conn, game_path(@conn, :create), [as: :game], fn f -> %>
-  <div class="input-group">
-    <%= text_input f, :name, placeholder: "Enter a game name", autofocus: true, class: "form-control" %>
+<%= form_for @conn, game_path(@conn, :create), [as: :game, class: "form"], fn f -> %>
+  <div class="field">
+    <div class="field__input">
+      <%= text_input f, :name, placeholder: "Type a new name to create a game", autofocus: true, class: "form-control" %>
+    </div>
 
-    <span class="input-group-btn">
-      <%= submit "Play", class: "btn btn-primary" %>
-    </span>
+    <div class="field__button">
+      <%= submit "Create", class: "btn btn-primary btn-block" %>
+    </div>
   </div>
-  <% end %>
-</div>
+<% end %>
+
+<h1>Active games</h1>
+
+<%= live_render(@conn, GameUiWeb.GameListLive) %>

--- a/apps/game_ui/lib/game_ui_web/templates/game/new.html.eex
+++ b/apps/game_ui/lib/game_ui_web/templates/game/new.html.eex
@@ -1,3 +1,5 @@
+<%= live_render(@conn, GameUiWeb.GameListLive) %>
+
 <%= form_for @conn, game_path(@conn, :create), [as: :game, class: "form"], fn f -> %>
   <div class="field">
     <div class="field__input">
@@ -10,6 +12,3 @@
   </div>
 <% end %>
 
-<h1>Active games</h1>
-
-<%= live_render(@conn, GameUiWeb.GameListLive) %>


### PR DESCRIPTION
Now users can see active games before creating a new game. Also, new games will appear in realtime for users who are in the new game's page.

### Gifs

This gif exemplify games being created for other users but using a iex session. So in the game' page you can see those new games.

![2019-10-19 16 42 23](https://user-images.githubusercontent.com/27698968/67146044-8f4dda80-f28f-11e9-825b-b5cdea7efd30.gif)


