### PR TITLE
Include assets installation in setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ In the end, players can restart the game if they want to.
 $ git clone git@github.com:feliperenan/tictactoe.git
 $ cd tictactoe
 $ mix deps.get
-$ mix phx.server
+$ cd apps/game_ui/assets && npm install
+$ cd ../../../ && mix phx.server
 ```
 
 Go to localhost:4000 and the game is going to be ready to play.


### PR DESCRIPTION
When I was setting the project up, I noticed that the command to install the front-end dependencies was missing. I think it's good to include it in the `README.md` especially because this project uses umbrella apps - e.g. it was not clear for me that I had to go to the `game_ui` directory in order to install them.