### PR TITLE
UI tweaks

### DIFF
--- a/apps/game_ui/assets/css/board.css
+++ b/apps/game_ui/assets/css/board.css
@@ -20,8 +20,9 @@
     background-color: #DC6859;
   }
 
-  .board .x-mark:hover, .board .o-mark:hover {
+  .board .x-mark:hover, .board .o-mark:hover, .board td[data-disabled] {
     background-color: transparent;
+    cursor: default;
   }
 }
 

--- a/apps/game_ui/assets/css/header.css
+++ b/apps/game_ui/assets/css/header.css
@@ -18,7 +18,6 @@ header .header-title {
   font-size: 2.5rem;
   font-weight: 500;
   font-style: italic;
-  word-spacing: -3px;
   margin-bottom: 0rem;
 }
 

--- a/apps/game_ui/lib/game_ui_web/templates/game/show.html.leex
+++ b/apps/game_ui/lib/game_ui_web/templates/game/show.html.leex
@@ -4,8 +4,12 @@
       <%= for positions <- split_in_rows_with_index(@game, 3) do %>
         <tr>
           <%= for {symbol, index} <- positions do %>
-            <td class=<%= "#{symbol}-mark" %> phx-click="put_symbol" phx-value-index="<%= index %>">
-            </td>
+            <%= if player_turn?(@game, @player) do %>
+              <td class=<%= "#{symbol}-mark" %> phx-click="put_symbol" phx-value-index="<%= index %>">
+              </td>
+            <% else %>
+              <td class=<%= "#{symbol}-mark" %> data-disabled="true"></td>
+            <% end %>
           <% end %>
         </tr>
       <% end %>

--- a/apps/game_ui/lib/game_ui_web/templates/layout/app.html.eex
+++ b/apps/game_ui/lib/game_ui_web/templates/layout/app.html.eex
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <title>GameUi · Phoenix Framework</title>
+    <title>Tic Tac Toe game in Elixir</title>
     <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>"/>
   </head>
   <body>

--- a/apps/game_ui/lib/game_ui_web/views/game_view.ex
+++ b/apps/game_ui/lib/game_ui_web/views/game_view.ex
@@ -30,4 +30,19 @@ defmodule GameUiWeb.GameView do
   def winner_name(game) do
     Map.get(game, game.winner)
   end
+
+  @doc """
+  Checks whether it's a player's turn or not.
+
+  Examples:
+
+    iex> GameUiWeb.GameView.player_turn?(%{next: :x}, %{symbol: :x})
+    true
+
+    iex> GameUiWeb.GameView.player_turn?(%{next: :y}, %{symbol: :x})
+    false
+
+  Returns a Boolean.
+  """
+  def player_turn?(%{next: next}, %{symbol: symbol}), do: next == symbol
 end


### PR DESCRIPTION
## Summary
This pull request includes some UI tweaks that I thought could be useful while I was developing #5. Let me know what you think about them.

## Changes included

### Do not highlight positions when it's the opponent turn
Before this change, the board positions would always be highlighted - i.e. hover effect - even when it's not my turn to play. Now, they're only highlighted when it's my turn to play. 
The new behavior is demostrated on the GIF below:
![Kapture 2019-10-07 at 19 34 28](https://user-images.githubusercontent.com/3727827/66354080-2d5dae80-e93a-11e9-8a03-62c48c02669a.gif)

### Change page title
I noticed that the page title was Phoenix's default one, so I decided to update it to a more descriptive title. 

### Remove `word-spacing` from logo
The log was broken on Safari due to the `word-spacing` CSS property - which doesn't seem to work on Safari. I couldn't find a good solution for this, so I decided to remove it since it doesn't look that much different without it. 

#### Safari - before
![Screen Shot 2019-10-08 at 09 12 02](https://user-images.githubusercontent.com/3727827/66394517-b9f48500-e9ab-11e9-9c5c-768b5ae77fb2.png)

#### Safari - now
![Screen Shot 2019-10-08 at 09 12 40](https://user-images.githubusercontent.com/3727827/66394538-cb3d9180-e9ab-11e9-88c4-1ee1c1a265d2.png)

#### Chrome - before
<img width="205" alt="Screen Shot 2019-10-08 at 09 13 36" src="https://user-images.githubusercontent.com/3727827/66394593-ed371400-e9ab-11e9-83ad-5ffb457cc898.png">

#### Chrome - now
<img width="196" alt="Screen Shot 2019-10-08 at 09 13 59" src="https://user-images.githubusercontent.com/3727827/66394616-fa540300-e9ab-11e9-96c8-848447231945.png">

I'm not really happy about this change, so let me know if you think it's better to revert it.